### PR TITLE
Use bitstream.bin instead of a design dependent name for the bitstream

### DIFF
--- a/sim/run_simulation.sh
+++ b/sim/run_simulation.sh
@@ -2,7 +2,7 @@
 set -ex
 DESIGN=counter
 OUTPUT=../output_files
-BITSTREAM=${OUTPUT}/${DESIGN}.bin
+BITSTREAM=${OUTPUT}/bitstream.bin
 VERILOG=../fabric/verilog
 MAX_BITBYTES=16384
 USER_DESIGN=../user_design/


### PR DESCRIPTION
Just a small fix to comply with the project structure updates.