### PR TITLE
corrected_gpio_config_builder

### DIFF
--- a/gpio_test/build_custom_firmware/Makefile
+++ b/gpio_test/build_custom_firmware/Makefile
@@ -27,7 +27,7 @@ check: gpio_config_def.py gpio_config_io.py gen_config_header
 flash_caravel: $(FIRMWARE_FILE)  check hex $(BITSTREAM_HEADER)
 	@echo
 	@echo "Start flashing Caravel."
-	python3 ../util/caravel_hkflash.py  $<
+	sudo python3 ../util/caravel_hkflash.py  $<
 	@echo "$(GREEN)Done flashing Caravel.$(RESET_COLOR)"
 
 flash_nucleo: gen_config_header $(FIRMWARE_FILE) flash

--- a/gpio_test/build_custom_firmware/Makefile
+++ b/gpio_test/build_custom_firmware/Makefile
@@ -27,7 +27,7 @@ check: gpio_config_def.py gpio_config_io.py gen_config_header
 flash_caravel: $(FIRMWARE_FILE)  check hex $(BITSTREAM_HEADER)
 	@echo
 	@echo "Start flashing Caravel."
-	sudo python3 ../util/caravel_hkflash.py  $<
+	python3 ../util/caravel_hkflash.py  $<
 	@echo "$(GREEN)Done flashing Caravel.$(RESET_COLOR)"
 
 flash_nucleo: gen_config_header $(FIRMWARE_FILE) flash

--- a/gpio_test/gpio_config/gpio_config_builder.py
+++ b/gpio_test/gpio_config/gpio_config_builder.py
@@ -54,14 +54,12 @@ def build_stream_dependent(stream, config):
         s = stream + "1100000000000"
     return s
 
-dum=1
 
 def build_stream_independent(stream, config):
     s = ""
     if config == C_MGMT_OUT:
         # stream += '110000000100'
         s = stream + "110000000000"
-                   # 1100000000001
     elif config == C_MGMT_IN:
         s = stream + "100000000001"
     elif config == C_DISABLE:
@@ -91,7 +89,7 @@ def build_stream_none(stream, config):
     elif config == C_MGMT_IN:
         s = stream + "1000000000011"
     elif config == C_DISABLE:
-        s = stream + "0000000000000"   
+        s = stream + "0000000000000"
     elif config == C_ALL_ONES:
         s = stream + "1111111111111"
     elif config == C_USER_BIDIR_WPU:
@@ -152,10 +150,8 @@ for k in reversed(range(NUM_IO)):
         stream_l = build_stream_independent(stream_l, config_l[k])
     elif gpio_l[k][1] == H_SPECIAL:
         stream_l = build_stream_special(stream_l, config_l[k])
-    elif gpio_l[k][1] == H_NONE: #generalise this may be by using NUM_IO and knowing which pin is faulty and just hard coding that pin's stream based on the violation type
-        #stream_l = build_stream_none(stream_l, config_l[k]+2)
-        #if config_l[k] == C_DISABLE:
-            stream_l = stream_l + "1000000000000"
+    elif gpio_l[k][1] == H_NONE:
+        stream_l = stream_l + "1000000000000"
     else:
         stream_l = build_stream_none(stream_l, config_l[k])
 
@@ -223,6 +219,3 @@ for x in config_stream:
 f.write(" };\n")
 
 f.close()
-
-
-print("hefiw````````````````````ugfiwgfiubgifrb")

--- a/gpio_test/gpio_config/gpio_config_builder.py
+++ b/gpio_test/gpio_config/gpio_config_builder.py
@@ -54,12 +54,14 @@ def build_stream_dependent(stream, config):
         s = stream + "1100000000000"
     return s
 
+dum=1
 
 def build_stream_independent(stream, config):
     s = ""
     if config == C_MGMT_OUT:
         # stream += '110000000100'
         s = stream + "110000000000"
+                   # 1100000000001
     elif config == C_MGMT_IN:
         s = stream + "100000000001"
     elif config == C_DISABLE:
@@ -89,7 +91,7 @@ def build_stream_none(stream, config):
     elif config == C_MGMT_IN:
         s = stream + "1000000000011"
     elif config == C_DISABLE:
-        s = stream + "0000000000000"
+        s = stream + "0000000000000"   
     elif config == C_ALL_ONES:
         s = stream + "1111111111111"
     elif config == C_USER_BIDIR_WPU:
@@ -123,6 +125,7 @@ def correct_dd_holds(stream, bpos):
             skip = True
         else:
             skip = False
+
     return "".join(bits)
 
 
@@ -149,6 +152,10 @@ for k in reversed(range(NUM_IO)):
         stream_l = build_stream_independent(stream_l, config_l[k])
     elif gpio_l[k][1] == H_SPECIAL:
         stream_l = build_stream_special(stream_l, config_l[k])
+    elif gpio_l[k][1] == H_NONE: #generalise this may be by using NUM_IO and knowing which pin is faulty and just hard coding that pin's stream based on the violation type
+        #stream_l = build_stream_none(stream_l, config_l[k]+2)
+        #if config_l[k] == C_DISABLE:
+            stream_l = stream_l + "1000000000000"
     else:
         stream_l = build_stream_none(stream_l, config_l[k])
 
@@ -216,3 +223,6 @@ for x in config_stream:
 f.write(" };\n")
 
 f.close()
+
+
+print("hefiw````````````````````ugfiwgfiubgifrb")


### PR DESCRIPTION
Issue:
The GPIO configuration builder did not correctly handle the initial case, causing the configuration for pin[1] to fail. This resulted in incorrect SPI interface settings.
Fix:
The code has been updated to ensure that the configuration of pin[0] fails gracefully while correctly configuring pin[1]. This adjustment ensures that the SPI interface is now properly configured.
Impact:
With this fix, the FPGA can be reflashed without needing to power it off.