### PR TITLE
Fix Makefile by removing software UART

### DIFF
--- a/gpio_test/nucleo_firmware/Makefile
+++ b/gpio_test/nucleo_firmware/Makefile
@@ -21,7 +21,6 @@ INCLUDES := \
 	-I../firmware_helpers/bitstream \
 	-I../firmware_helpers/register_actions \
 	-I../firmware_helpers/helpers \
-	-I../firmware_helpers/uart \
 	-I../firmware_helpers/global_defs
 
 SRC_FILES := \
@@ -34,7 +33,6 @@ SRC_FILES := \
 	$(THIS_MAKEFILE_DIR)../firmware_helpers/gpio/gpio.c \
 	$(THIS_MAKEFILE_DIR)../firmware_helpers/register_actions/register_actions.c \
 	$(THIS_MAKEFILE_DIR)../firmware_helpers/helpers/helpers.c \
-	$(THIS_MAKEFILE_DIR)../firmware_helpers/uart/software_uart.c \
 
 TOOLCHAIN_PREFIX := riscv64-unknown-elf
 PATTERN ?= config_io_o


### PR DESCRIPTION
In the previous commits the software UART files were removed from the repo, but the paths where still in the inlcude paths of the Makefile. This removes the software UART from the Makefile.