### PR TITLE
Fix digitpot settings

### DIFF
--- a/gpio_test/nucleo_firmware/Makefile
+++ b/gpio_test/nucleo_firmware/Makefile
@@ -88,6 +88,7 @@ compile: $(MPY_FILES)
 
 $(PYTHON_SRC)%.mpy: $(PYTHON_SRC)%.py
 	mpy-cross $<
+	$(COPY_CMD) $@ $(FLASH)
 
 # runs script from the local filesystem
 reset: check_device
@@ -154,8 +155,6 @@ F413ZH:
 
 # copies scripts to nucleo
 copy2 F746ZG-copy: compile check_device hex
-	$(COPY_CMD) $(filter-out $(PYTHON_SRC)main.mpy, $(wildcard $(PYTHON_SRC)*.mpy)) $(FLASH)
-	$(COPY_CMD) $(PYTHON_SRC)/main.py $(FLASH)
 	$(COPY_CMD) $(THIS_MAKEFILE_DIR)config_io_o.hex $(FLASH)
 	sync
 	$(LS_CMD) $(FLASH)
@@ -163,8 +162,6 @@ copy2 F746ZG-copy: compile check_device hex
 	mpremote df
 
 copy3 F413ZH-copy: compile check_device hex
-	$(COPY_CMD) $(filter-out $(PYTHON_SRC)main.mpy, $(wildcard $(PYTHON_SRC)*.mpy)) $(FLASH)
-	$(COPY_CMD) $(PYTHON_SRC)main.py $(FLASH)
 	$(COPY_CMD) $(THIS_MAKEFILE_DIR)config_io_o.hex $(FLASH)
 	sync
 	$(LS_CMD)


### PR DESCRIPTION
Previously the Caravel board used the MCP4661 as a digital potentiometer. In the Nucleo HAT REV 2A version, the MCP4641 is however used. Since the MCP4661 uses 8 bits for the resistance configuration and the MCP4641 uses 7 bits, the existing scripts result in a wrong output voltage. This PR fixes this issue. In the future, the setting for which device is used could be given by the Makefile.

Here is the link to the datasheet for reference: 
https://ww1.microchip.com/downloads/en/DeviceDoc/22107B.pdf