### PR TITLE
Clean up and add files for MPW4 tests

### DIFF
--- a/gpio_test/Makefile.common
+++ b/gpio_test/Makefile.common
@@ -18,7 +18,7 @@ CONFIG_FILE_TARGET = $(CONFIG_FILES_DIR)/$(PART_OUTPUT_DIR)/$(PART_OUTPUT_FILE)
 TOOLCHAIN_PREFIX := riscv64-unknown-elf
 
 # Compiler and linker flags
-CFLAGS := -O3 -g -mabi=ilp32 -march=rv32i_zicsr -D__vexriscv__ -ffreestanding -nostdlib
+CFLAGS := -O3 -Wall -Wpedantic -g -mabi=ilp32 -march=rv32i_zicsr -D__vexriscv__ -ffreestanding -nostdlib
 LDSCRIPT := ../riscv_firmware_src/sections.lds
 LDFLAGS := -Wl,-Bstatic,-T,$(LDSCRIPT),--strip-debug
 

--- a/gpio_test/build_efpga_firmware/gpio_config_firmware_MPW2.c
+++ b/gpio_test/build_efpga_firmware/gpio_config_firmware_MPW2.c
@@ -1,30 +1,29 @@
-#include "../gpio_config/gpio_config_io.h"
-#include <bitstream.h>
 #include <defs.h>
 #include <global_defs.h>
 #include <gpio_config_data.h>
+#include <gpio_config_io.h>
 #include <helpers.h>
 #include <register_actions.h>
 #include <stub.h>
 
 int main() {
-    reg_gpio_mode1 = 1;
-    reg_gpio_mode0 = 0;
-    reg_gpio_ien = 1;
-    reg_gpio_oe = 1;
-    reg_gpio_out = 1;
+  reg_gpio_mode1 = 1;
+  reg_gpio_mode0 = 0;
+  reg_gpio_ien = 1;
+  reg_gpio_oe = 1;
+  reg_gpio_out = 1;
 
-    blink(6, 2500000);
+  blink(6, 2500000);
 
-    // Configure the IOs so the eFPGA has access to them
-    reg_gpio_out = 1;
-    gpio_config_io(config_stream);
+  // Configure the IOs so the eFPGA has access to them
+  reg_gpio_out = 1;
+  gpio_config_io(config_stream);
 
-    blink(3, 2500000);
-    reg_gpio_out = 0;
+  blink(3, 2500000);
+  reg_gpio_out = 0;
 
-    while (1) {
-    }
+  while (1) {
+  }
 
-    return 0;
+  return 0;
 }

--- a/gpio_test/build_efpga_firmware/gpio_config_firmware_MPW4.c
+++ b/gpio_test/build_efpga_firmware/gpio_config_firmware_MPW4.c
@@ -1,0 +1,30 @@
+#include <bitstream.h>
+#include <defs.h>
+#include <global_defs.h>
+#include <gpio_config_data.h>
+#include <gpio_config_io.h>
+#include <helpers.h>
+#include <register_actions.h>
+#include <stub.h>
+
+int main() {
+  reg_gpio_mode1 = 1;
+  reg_gpio_mode0 = 0;
+  reg_gpio_ien = 1;
+  reg_gpio_oe = 1;
+  reg_gpio_out = 1;
+
+  blink(6, 2500000);
+
+  // Configure the IOs so the eFPGA has access to them
+  reg_gpio_out = 1;
+  gpio_config_io(config_stream);
+
+  blink(3, 2500000);
+  reg_gpio_out = 0;
+
+  while (1) {
+  }
+
+  return 0;
+}

--- a/gpio_test/build_efpga_firmware/gpio_config_firmware_MPW5.c
+++ b/gpio_test/build_efpga_firmware/gpio_config_firmware_MPW5.c
@@ -1,35 +1,34 @@
-#include "../gpio_config/gpio_config_io.h"
-#include <bitstream.h>
 #include <defs.h>
 #include <global_defs.h>
 #include <gpio_config_data.h>
+#include <gpio_config_io.h>
 #include <helpers.h>
 #include <register_actions.h>
 #include <stub.h>
 
 int main() {
-    reg_gpio_mode1 = 1;
-    reg_gpio_mode0 = 0;
-    reg_gpio_ien = 1;
-    reg_gpio_oe = 1;
-    reg_gpio_out = 1;
+  reg_gpio_mode1 = 1;
+  reg_gpio_mode0 = 0;
+  reg_gpio_ien = 1;
+  reg_gpio_oe = 1;
+  reg_gpio_out = 1;
 
-    reg_mprj_datal =
-        (1u << REGISTER_7_DATA_BIT_POS) | (1u << REGISTER_8_DATA_BIT_POS) |
-        (1u << REGISTER_9_DATA_BIT_POS) | (1u << REGISTER_10_DATA_BIT_POS) |
-        (1u << REGISTER_11_DATA_BIT_POS) | (1u << REGISTER_12_DATA_BIT_POS);
+  reg_mprj_datal =
+      (1u << REGISTER_7_DATA_BIT_POS) | (1u << REGISTER_8_DATA_BIT_POS) |
+      (1u << REGISTER_9_DATA_BIT_POS) | (1u << REGISTER_10_DATA_BIT_POS) |
+      (1u << REGISTER_11_DATA_BIT_POS) | (1u << REGISTER_12_DATA_BIT_POS);
 
-    blink(6, 2500000);
+  blink(12, 2500000);
 
-    // Configure the IOs so the eFPGA has access to them
-    reg_gpio_out = 1;
-    gpio_config_io(config_stream);
+  // Configure the IOs so the eFPGA has access to them
+  reg_gpio_out = 1;
+  gpio_config_io(config_stream);
 
-    blink(3, 2500000);
-    reg_gpio_out = 0;
+  blink(3, 2500000);
+  reg_gpio_out = 0;
 
-    while (1) {
-    }
+  while (1) {
+  }
 
-    return 0;
+  return 0;
 }

--- a/gpio_test/build_efpga_firmware/gpio_config_io_MPW4.py
+++ b/gpio_test/build_efpga_firmware/gpio_config_io_MPW4.py
@@ -1,0 +1,63 @@
+# number of IO in the configuration stream for each chain
+NUM_IO = 19
+
+# defines these values for IO configurations
+C_MGMT_OUT = 0
+C_MGMT_IN = 1
+C_USER_BIDIR = 2
+C_DISABLE = 3
+C_ALL_ONES = 4
+C_USER_BIDIR_WPU = 5
+C_USER_BIDIR_WPD = 6
+C_USER_IN_NOPULL = 7
+C_USER_OUT = 8
+C_MGMT_HIGH_Z_STRONG_0_DISABLE_OUTPUT = 9
+C_MGMT_HIGH_Z_STRONG_0 = 10
+
+config_h = [
+    C_DISABLE,  # 37
+    C_DISABLE,  # 36
+    C_DISABLE,  # 35
+    C_DISABLE,  # 34
+    C_DISABLE,  # 33
+    C_DISABLE,  # 32
+    C_DISABLE,  # 31
+    C_DISABLE,  # 30
+    C_DISABLE,  # 29
+    C_DISABLE,  # 28
+    C_DISABLE,  # 27
+    C_USER_BIDIR_WPU,  # 26 - io 9
+    C_USER_BIDIR_WPU,  # 25 - io 8
+    C_USER_BIDIR_WPU,  # 24 - io 7
+    C_USER_BIDIR_WPU,  # 23 - io 6
+    C_USER_BIDIR_WPU,  # 22 - io 5
+    C_USER_BIDIR_WPU,  # 21 - io 4
+    C_USER_BIDIR_WPU,  # 20 - io 3
+    C_USER_BIDIR_WPU,  # 19 - io 2
+]
+
+del config_h[NUM_IO:]
+
+config_l = [
+    C_ALL_ONES,  # 0
+    C_MGMT_IN,  # 1 - CLK_SEL_0
+    C_MGMT_IN,  # 2 - CLK_SEL_1
+    C_MGMT_IN,  # 3 - s_clk
+    C_MGMT_IN,  # 4 - s_data
+    C_MGMT_IN,  # 5 - Rx
+    C_MGMT_IN,  # 6 - Receive LED
+    C_MGMT_IN,  # 7 - Fetch enable
+    C_MGMT_IN,  # 8 - ICESOC UART Rx
+    C_MGMT_IN,  # 9 - ICESOC UART to mem Rx
+    C_MGMT_IN,  # 10 - ICESOC UART Tx
+    C_MGMT_IN,  # 11 - ICESOC UART to mem Tx
+    C_MGMT_IN,  # 12 - ICESOC Error UART to mem
+    C_DISABLE,  # 13 - Unused
+    C_DISABLE,  # 14 - Unused
+    C_DISABLE,  # 15 - Unused
+    C_MGMT_IN,  # 16 - ICESOC eFPGA Write Strobe 2
+    C_USER_BIDIR_WPU,  # 17 - io 0
+    C_USER_BIDIR_WPU,  # 18 - io 1
+]
+
+del config_l[NUM_IO:]

--- a/gpio_test/build_efpga_firmware/wb_to_sram_MPW4.c
+++ b/gpio_test/build_efpga_firmware/wb_to_sram_MPW4.c
@@ -1,0 +1,67 @@
+#include "../gpio_config/gpio_config_io.h"
+#include <stdint.h>
+
+#include <defs.h>
+#include <global_defs.h>
+#include <gpio_config_data.h>
+#include <helpers.h>
+#include <register_actions.h>
+#include <stub.h>
+
+#define RESET_VECTOR_WORD_ADDRESS 32 // 128 / 8
+#define NUM_WORDS 10
+#define TEST_WORD 0xBADCAFFE
+
+#define SRAM_2_OFFSET 0x100                    // 0x400 / 4
+#define SRAM_LAST_ACCESSIBLE_WORD_ADDRESS 0x3F // 0FF / 4
+#define PROGRAM_START_ADDRESS 0x20             // 0x80 / 4
+
+int main() {
+  reg_gpio_mode1 = 1;
+  reg_gpio_mode0 = 0;
+  reg_gpio_ien = 1;
+  reg_gpio_oe = 1;
+  reg_gpio_out = 1;
+  reg_wb_enable = 1;
+  reg_hkspi_disable = 1;
+
+  reg_gpio_out = 0;
+
+  // Set LA bits 0-3 as outputs
+  reg_la0_oenb = reg_la0_oenb & ~0xF;
+  //
+  // Set Ibex control bits to zero
+  reg_la0_data = 0u;
+
+  volatile uint32_t *sram1 = (uint32_t *)&reg_mprj_slave;
+  volatile uint32_t *sram2 = (uint32_t *)&reg_mprj_slave + SRAM_2_OFFSET;
+
+  uint8_t fail;
+
+  reg_mprj_datal = 0x1;
+
+  while (1) {
+    sram1[0] = TEST_WORD;
+    sram1[0] = TEST_WORD;
+    if (sram1[0] == TEST_WORD) {
+      fail = 0;
+    } else {
+      fail = 1;
+    }
+    if (sram1[0] == TEST_WORD) {
+      fail = 0;
+    } else {
+      fail = 1;
+    }
+    if (fail) {
+      blink(3, 500000);
+      reg_mprj_datal = reg_mprjdata_l = 0x2;
+    } else {
+      reg_mprj_datal = 0x3;
+      blink(3, 100000);
+    }
+    delay(1000000);
+  }
+
+  return 0;
+}

--- a/gpio_test/firmware_helpers/upload_bitstream/upload_bitstream.c
+++ b/gpio_test/firmware_helpers/upload_bitstream/upload_bitstream.c
@@ -22,11 +22,11 @@
 #define CTRL_WORD_ENABLE_BITBANG 0x0000FAB1u
 
 #define EXTRACT_BYTE_FROM_WORD(word, byte_index)                               \
-    (((word) >> (BITS_IN_BYTE * byte_index)) & 0xFFu)
+  (((word) >> (BITS_IN_BYTE * byte_index)) & 0xFFu)
 #define GET_BIT_AS_BOOL_FROM_BYTE(byte, index)                                 \
-    ((bool)(((byte) >> (index)) & 0x01u))
+  ((bool)(((byte) >> (index)) & 0x01u))
 #define MODULO_4(data)                                                         \
-    (data & 0x03u) // Just using the last two bits is effectively modulo 4
+  (data & 0x03u) // Just using the last two bits is effectively modulo 4
 
 #define DELAY 50u
 
@@ -54,97 +54,96 @@ void bitstream_init(GPIO *const gpio) { gpio_init(gpio); }
  */
 void upload_bitstream(uint8_t const *const bitstream_data,
                       uint32_t bitream_size) {
-    // Reset user logic
+  // Reset user logic
 #ifndef GTEST
-    data_reg_shadow |= REGISTER_DATA_BIT(RESET_REGISTER);
-    reg_mprj_datal = data_reg_shadow;
+  data_reg_shadow |= REGISTER_DATA_BIT(RESET_REGISTER);
+  reg_mprj_datal = data_reg_shadow;
 #endif
-    uint32_t ctrl = CTRL_WORD_ENABLE_BITBANG;
 
-    // Loop from first to last byte. Inside the byte loop from MSB to LSB.
-    for (uint8_t byte_pos = 0u; byte_pos < PREAMBLE_SIZE; byte_pos++) {
-        uint8_t control_word_byte_pos =
-            MODULO_4(~byte_pos); // Invert because we want to start from the
-                                 // most significant byte.
-        uint8_t current_control_word_byte = EXTRACT_BYTE_FROM_WORD(
-            CTRL_WORD_ENABLE_BITBANG, control_word_byte_pos);
-        transmit_byte(0xFF, current_control_word_byte);
-    }
+  // Loop from first to last byte. Inside the byte loop from MSB to LSB.
+  for (uint8_t byte_pos = 0u; byte_pos < PREAMBLE_SIZE; byte_pos++) {
+    uint8_t control_word_byte_pos =
+        MODULO_4(~byte_pos); // Invert because we want to start from the
+                             // most significant byte.
+    uint8_t current_control_word_byte =
+        EXTRACT_BYTE_FROM_WORD(CTRL_WORD_ENABLE_BITBANG, control_word_byte_pos);
+    transmit_byte(0xFF, current_control_word_byte);
+  }
 
-    for (uint32_t byte_pos = 0u; byte_pos < bitream_size; byte_pos++) {
-        uint8_t current_byte = bitstream_data[byte_pos];
-        uint8_t control_word_byte_pos =
-            MODULO_4(~byte_pos); // Invert because we want to start from the
-                                 // most significant byte.
-        uint8_t current_control_word_byte = EXTRACT_BYTE_FROM_WORD(
-            CTRL_WORD_ENABLE_BITBANG, control_word_byte_pos);
+  for (uint32_t byte_pos = 0u; byte_pos < bitream_size; byte_pos++) {
+    uint8_t current_byte = bitstream_data[byte_pos];
+    uint8_t control_word_byte_pos =
+        MODULO_4(~byte_pos); // Invert because we want to start from the
+                             // most significant byte.
+    uint8_t current_control_word_byte =
+        EXTRACT_BYTE_FROM_WORD(CTRL_WORD_ENABLE_BITBANG, control_word_byte_pos);
 
-        transmit_byte(current_byte, current_control_word_byte);
-    }
+    transmit_byte(current_byte, current_control_word_byte);
+  }
 
-    for (uint8_t byte_pos = 0u; byte_pos < PREAMBLE_SIZE; byte_pos++) {
-        uint8_t control_word_byte_pos =
-            MODULO_4(~byte_pos); // Invert because we want to start from the
-                                 // most significant byte.
-        uint8_t current_control_word_byte = EXTRACT_BYTE_FROM_WORD(
-            CTRL_WORD_DISABLE_BITBANG, control_word_byte_pos);
-        transmit_byte(0x00, current_control_word_byte);
-    }
+  for (uint8_t byte_pos = 0u; byte_pos < PREAMBLE_SIZE; byte_pos++) {
+    uint8_t control_word_byte_pos =
+        MODULO_4(~byte_pos); // Invert because we want to start from the
+                             // most significant byte.
+    uint8_t current_control_word_byte = EXTRACT_BYTE_FROM_WORD(
+        CTRL_WORD_DISABLE_BITBANG, control_word_byte_pos);
+    transmit_byte(0x00, current_control_word_byte);
+  }
 
 #ifndef GTEST
-    clear_bit(S_CLK_REGISTER, &HARDWARE_REGISTER);
-    clear_bit(S_DATA_REGISTER, &HARDWARE_REGISTER);
+  clear_bit(S_CLK_REGISTER, &HARDWARE_REGISTER);
+  clear_bit(S_DATA_REGISTER, &HARDWARE_REGISTER);
 #endif
 }
 
 static void transmit_byte(uint8_t data_byte, uint8_t ctrl_word_byte) {
-    for (int32_t bit_pos = (int32_t)MSB_IN_BYTE; bit_pos >= 0; bit_pos--) {
-        bool set;
+  for (int32_t bit_pos = (int32_t)MSB_IN_BYTE; bit_pos >= 0; bit_pos--) {
+    bool set;
 
-        set = GET_BIT_AS_BOOL_FROM_BYTE(data_byte, bit_pos);
+    set = GET_BIT_AS_BOOL_FROM_BYTE(data_byte, bit_pos);
 #ifdef USE_FUNCTIONS
-        set_or_clear_gpio(PIN_SDATA, set);
+    set_or_clear_gpio(PIN_SDATA, set);
 #else
-        if (set)
-            data_reg_shadow |= REGISTER_DATA_BIT(S_DATA_REGISTER);
-        else
-            data_reg_shadow &= ~(REGISTER_DATA_BIT(S_DATA_REGISTER));
-        HARDWARE_REGISTER = data_reg_shadow;
+    if (set)
+      data_reg_shadow |= REGISTER_DATA_BIT(S_DATA_REGISTER);
+    else
+      data_reg_shadow &= ~(REGISTER_DATA_BIT(S_DATA_REGISTER));
+    HARDWARE_REGISTER = data_reg_shadow;
 #endif
 
 #ifdef USE_FUNCTIONS
-        set_gpio(PIN_SCLK);
-#else
-        data_reg_shadow |= REGISTER_DATA_BIT(S_CLK_REGISTER);
-        HARDWARE_REGISTER = data_reg_shadow;
-#endif
-
-        set = GET_BIT_AS_BOOL_FROM_BYTE(ctrl_word_byte, bit_pos);
-
-#ifdef USE_FUNCTIONS
-        set_or_clear_gpio(PIN_SDATA, set);
-#else
-        if (set)
-            data_reg_shadow |= REGISTER_DATA_BIT(S_DATA_REGISTER);
-        else
-            data_reg_shadow &= ~(REGISTER_DATA_BIT(S_DATA_REGISTER));
-        HARDWARE_REGISTER = data_reg_shadow;
-#endif
-#ifdef USE_FUNCTIONS
-        clear_gpio(PIN_SCLK);
-#else
-        data_reg_shadow &= ~(REGISTER_DATA_BIT(S_CLK_REGISTER));
-        HARDWARE_REGISTER = data_reg_shadow;
-#endif
-    }
-    /*
-    // This is only needed when comparing the bitstream to a known good.
-#ifdef GTEST
-    // Used to format the printed bitstream in the test
-    if ((byte_pos + 1) % 4 == 0)
-    {
     set_gpio(PIN_SCLK);
-    }
+#else
+    data_reg_shadow |= REGISTER_DATA_BIT(S_CLK_REGISTER);
+    HARDWARE_REGISTER = data_reg_shadow;
+#endif
+
+    set = GET_BIT_AS_BOOL_FROM_BYTE(ctrl_word_byte, bit_pos);
+
+#ifdef USE_FUNCTIONS
+    set_or_clear_gpio(PIN_SDATA, set);
+#else
+    if (set)
+      data_reg_shadow |= REGISTER_DATA_BIT(S_DATA_REGISTER);
+    else
+      data_reg_shadow &= ~(REGISTER_DATA_BIT(S_DATA_REGISTER));
+    HARDWARE_REGISTER = data_reg_shadow;
+#endif
+#ifdef USE_FUNCTIONS
+    clear_gpio(PIN_SCLK);
+#else
+    data_reg_shadow &= ~(REGISTER_DATA_BIT(S_CLK_REGISTER));
+    HARDWARE_REGISTER = data_reg_shadow;
+#endif
+  }
+  /*
+  // This is only needed when comparing the bitstream to a known good.
+#ifdef GTEST
+  // Used to format the printed bitstream in the test
+  if ((byte_pos + 1) % 4 == 0)
+  {
+  set_gpio(PIN_SCLK);
+  }
 #endif
 }*/
 }

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_100/gpio_config_def_part_100_1_5_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_100/gpio_config_def_part_100_1_5_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 100
+# io_config -- version 1.2.2
+part = 100
+voltage = 1.50
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.5
+# configuration failed in gpio[18], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_DEPENDENT],
+    ['IO[2]', H_DEPENDENT],
+    ['IO[3]', H_DEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_DEPENDENT],
+    ['IO[7]', H_DEPENDENT],
+    ['IO[8]', H_DEPENDENT],
+    ['IO[9]', H_DEPENDENT],
+    ['IO[10]', H_DEPENDENT],
+    ['IO[11]', H_INDEPENDENT],
+    ['IO[12]', H_INDEPENDENT],
+    ['IO[13]', H_INDEPENDENT],
+    ['IO[14]', H_INDEPENDENT],
+    ['IO[15]', H_INDEPENDENT],
+    ['IO[16]', H_INDEPENDENT],
+    ['IO[17]', H_INDEPENDENT],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.5
+# configuration failed in gpio[19], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_DEPENDENT],
+['IO[35]', H_DEPENDENT],
+['IO[34]', H_DEPENDENT],
+['IO[33]', H_DEPENDENT],
+['IO[32]', H_DEPENDENT],
+['IO[31]', H_DEPENDENT],
+['IO[30]', H_DEPENDENT],
+['IO[29]', H_DEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_DEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_INDEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_11/gpio_config_def_part_11_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_11/gpio_config_def_part_11_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 11
+# io_config -- version 1.2.2
+part = 11
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_DEPENDENT],
+['IO[2]', H_DEPENDENT],
+['IO[3]', H_DEPENDENT],
+['IO[4]', H_DEPENDENT],
+['IO[5]', H_DEPENDENT],
+['IO[6]', H_DEPENDENT],
+['IO[7]', H_DEPENDENT],
+['IO[8]', H_DEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_DEPENDENT],
+['IO[12]', H_INDEPENDENT],
+['IO[13]', H_INDEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.45
+# configuration failed in gpio[35], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_DEPENDENT],
+['IO[35]', H_UNKNOWN],
+['IO[34]', H_UNKNOWN],
+['IO[33]', H_UNKNOWN],
+['IO[32]', H_UNKNOWN],
+['IO[31]', H_UNKNOWN],
+['IO[30]', H_UNKNOWN],
+['IO[29]', H_UNKNOWN],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_13/gpio_config_def_part_13_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_13/gpio_config_def_part_13_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 13
+# io_config -- version 1.2.2
+part = 13
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[1], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_UNKNOWN],
+    ['IO[2]', H_UNKNOWN],
+    ['IO[3]', H_UNKNOWN],
+    ['IO[4]', H_UNKNOWN],
+    ['IO[5]', H_UNKNOWN],
+    ['IO[6]', H_UNKNOWN],
+    ['IO[7]', H_UNKNOWN],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# configuration failed in gpio[36], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_UNKNOWN],
+['IO[35]', H_UNKNOWN],
+['IO[34]', H_UNKNOWN],
+['IO[33]', H_UNKNOWN],
+['IO[32]', H_UNKNOWN],
+['IO[31]', H_UNKNOWN],
+['IO[30]', H_UNKNOWN],
+['IO[29]', H_UNKNOWN],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_400/gpio_config_def_part_400_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_400/gpio_config_def_part_400_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 400
+# io_config -- version 1.2.2
+part = 400
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[8], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_DEPENDENT],
+    ['IO[3]', H_INDEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_DEPENDENT],
+    ['IO[7]', H_INDEPENDENT],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# configuration failed in gpio[22], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_DEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_400/gpio_config_def_part_400_1_5_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_400/gpio_config_def_part_400_1_5_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 400
+# io_config -- version 1.2.2
+part = 400
+voltage = 1.50
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.5
+# configuration failed in gpio[8], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_DEPENDENT],
+    ['IO[3]', H_INDEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_DEPENDENT],
+    ['IO[7]', H_INDEPENDENT],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.5
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_DEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_DEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_401/gpio_config_def_part_401_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_401/gpio_config_def_part_401_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 401
+# io_config -- version 1.2.2
+part = 401
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[10], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_INDEPENDENT],
+    ['IO[3]', H_DEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_DEPENDENT],
+    ['IO[7]', H_DEPENDENT],
+    ['IO[8]', H_DEPENDENT],
+    ['IO[9]', H_INDEPENDENT],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# configuration failed in gpio[26], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_INDEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_401/gpio_config_def_part_401_1_5_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_401/gpio_config_def_part_401_1_5_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 401
+# io_config -- version 1.2.2
+part = 401
+voltage = 1.50
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.5
+# configuration failed in gpio[15], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_INDEPENDENT],
+    ['IO[3]', H_DEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_DEPENDENT],
+    ['IO[7]', H_DEPENDENT],
+    ['IO[8]', H_DEPENDENT],
+    ['IO[9]', H_DEPENDENT],
+    ['IO[10]', H_DEPENDENT],
+    ['IO[11]', H_INDEPENDENT],
+    ['IO[12]', H_INDEPENDENT],
+    ['IO[13]', H_INDEPENDENT],
+    ['IO[14]', H_INDEPENDENT],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.5
+# configuration failed in gpio[26], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_INDEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_402/gpio_config_def_part_402_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_402/gpio_config_def_part_402_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 402
+# io_config -- version 1.2.2
+part = 402
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_DEPENDENT],
+['IO[3]', H_DEPENDENT],
+['IO[4]', H_INDEPENDENT],
+['IO[5]', H_DEPENDENT],
+['IO[6]', H_INDEPENDENT],
+['IO[7]', H_INDEPENDENT],
+['IO[8]', H_DEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_DEPENDENT],
+['IO[12]', H_INDEPENDENT],
+['IO[13]', H_DEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_DEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_INDEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_DEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_402/gpio_config_def_part_402_1_8_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_402/gpio_config_def_part_402_1_8_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 402
+# io_config -- version 1.2.2
+part = 402
+voltage = 1.80
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.8
+# configuration failed in gpio[13], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_DEPENDENT],
+    ['IO[3]', H_DEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_INDEPENDENT],
+    ['IO[7]', H_INDEPENDENT],
+    ['IO[8]', H_DEPENDENT],
+    ['IO[9]', H_DEPENDENT],
+    ['IO[10]', H_INDEPENDENT],
+    ['IO[11]', H_DEPENDENT],
+    ['IO[12]', H_INDEPENDENT],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.8
+# configuration failed in gpio[34], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_UNKNOWN],
+['IO[33]', H_UNKNOWN],
+['IO[32]', H_UNKNOWN],
+['IO[31]', H_UNKNOWN],
+['IO[30]', H_UNKNOWN],
+['IO[29]', H_UNKNOWN],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_403/gpio_config_def_part_403_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_403/gpio_config_def_part_403_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 403
+# io_config -- version 1.2.2
+part = 403
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_INDEPENDENT],
+['IO[3]', H_DEPENDENT],
+['IO[4]', H_INDEPENDENT],
+['IO[5]', H_DEPENDENT],
+['IO[6]', H_INDEPENDENT],
+['IO[7]', H_INDEPENDENT],
+['IO[8]', H_INDEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_DEPENDENT],
+['IO[12]', H_INDEPENDENT],
+['IO[13]', H_DEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_DEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_DEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_DEPENDENT],
+['IO[28]', H_INDEPENDENT],
+['IO[27]', H_DEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_DEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_404/gpio_config_def_part_404_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_404/gpio_config_def_part_404_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 404
+# io_config -- version 1.2.2
+part = 404
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[8], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_DEPENDENT],
+    ['IO[2]', H_INDEPENDENT],
+    ['IO[3]', H_DEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_INDEPENDENT],
+    ['IO[6]', H_INDEPENDENT],
+    ['IO[7]', H_INDEPENDENT],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# configuration failed in gpio[27], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_DEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_DEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_405/gpio_config_def_part_405_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_405/gpio_config_def_part_405_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 405
+# io_config -- version 1.2.2
+part = 405
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[8], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_DEPENDENT],
+    ['IO[3]', H_DEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_DEPENDENT],
+    ['IO[7]', H_INDEPENDENT],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# configuration failed in gpio[34], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_UNKNOWN],
+['IO[33]', H_UNKNOWN],
+['IO[32]', H_UNKNOWN],
+['IO[31]', H_UNKNOWN],
+['IO[30]', H_UNKNOWN],
+['IO[29]', H_UNKNOWN],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_406/gpio_config_def_part_406_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_406/gpio_config_def_part_406_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 406
+# io_config -- version 1.2.2
+part = 406
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_DEPENDENT],
+['IO[3]', H_DEPENDENT],
+['IO[4]', H_DEPENDENT],
+['IO[5]', H_INDEPENDENT],
+['IO[6]', H_DEPENDENT],
+['IO[7]', H_INDEPENDENT],
+['IO[8]', H_DEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_DEPENDENT],
+['IO[12]', H_INDEPENDENT],
+['IO[13]', H_DEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.45
+# configuration failed in gpio[26], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_DEPENDENT],
+['IO[35]', H_DEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_DEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_DEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_407/gpio_config_def_part_407_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_407/gpio_config_def_part_407_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 407
+# io_config -- version 1.2.2
+part = 407
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_DEPENDENT],
+['IO[2]', H_DEPENDENT],
+['IO[3]', H_DEPENDENT],
+['IO[4]', H_DEPENDENT],
+['IO[5]', H_DEPENDENT],
+['IO[6]', H_INDEPENDENT],
+['IO[7]', H_DEPENDENT],
+['IO[8]', H_DEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_INDEPENDENT],
+['IO[12]', H_INDEPENDENT],
+['IO[13]', H_DEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_DEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_DEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_DEPENDENT],
+['IO[20]', H_DEPENDENT],
+['IO[19]', H_INDEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_408/gpio_config_def_part_408_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_408/gpio_config_def_part_408_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 408
+# io_config -- version 1.2.2
+part = 408
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_DEPENDENT],
+['IO[3]', H_INDEPENDENT],
+['IO[4]', H_INDEPENDENT],
+['IO[5]', H_INDEPENDENT],
+['IO[6]', H_DEPENDENT],
+['IO[7]', H_INDEPENDENT],
+['IO[8]', H_DEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_DEPENDENT],
+['IO[12]', H_DEPENDENT],
+['IO[13]', H_INDEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_DEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_DEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_DEPENDENT],
+['IO[28]', H_INDEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_INDEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_409/gpio_config_def_part_409_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_409/gpio_config_def_part_409_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 409
+# io_config -- version 1.2.2
+part = 409
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[8], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_INDEPENDENT],
+    ['IO[3]', H_INDEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_DEPENDENT],
+    ['IO[7]', H_INDEPENDENT],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_DEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_410/gpio_config_def_part_410_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_410/gpio_config_def_part_410_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 410
+# io_config -- version 1.2.2
+part = 410
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[18], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_INDEPENDENT],
+    ['IO[3]', H_DEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_INDEPENDENT],
+    ['IO[7]', H_INDEPENDENT],
+    ['IO[8]', H_DEPENDENT],
+    ['IO[9]', H_DEPENDENT],
+    ['IO[10]', H_INDEPENDENT],
+    ['IO[11]', H_INDEPENDENT],
+    ['IO[12]', H_INDEPENDENT],
+    ['IO[13]', H_DEPENDENT],
+    ['IO[14]', H_INDEPENDENT],
+    ['IO[15]', H_INDEPENDENT],
+    ['IO[16]', H_INDEPENDENT],
+    ['IO[17]', H_INDEPENDENT],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_411/gpio_config_def_part_411_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_411/gpio_config_def_part_411_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 411
+# io_config -- version 1.2.2
+part = 411
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[9], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_INDEPENDENT],
+    ['IO[3]', H_INDEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_DEPENDENT],
+    ['IO[7]', H_INDEPENDENT],
+    ['IO[8]', H_DEPENDENT],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_DEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_412/gpio_config_def_part_412_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_412/gpio_config_def_part_412_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 412
+# io_config -- version 1.2.2
+part = 412
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[2], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_DEPENDENT],
+    ['IO[2]', H_UNKNOWN],
+    ['IO[3]', H_UNKNOWN],
+    ['IO[4]', H_UNKNOWN],
+    ['IO[5]', H_UNKNOWN],
+    ['IO[6]', H_UNKNOWN],
+    ['IO[7]', H_UNKNOWN],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# configuration failed in gpio[29], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_UNKNOWN],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_413/gpio_config_def_part_413_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_413/gpio_config_def_part_413_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 413
+# io_config -- version 1.2.2
+part = 413
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_DEPENDENT],
+['IO[3]', H_DEPENDENT],
+['IO[4]', H_DEPENDENT],
+['IO[5]', H_INDEPENDENT],
+['IO[6]', H_INDEPENDENT],
+['IO[7]', H_INDEPENDENT],
+['IO[8]', H_DEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_DEPENDENT],
+['IO[12]', H_INDEPENDENT],
+['IO[13]', H_INDEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.45
+# configuration failed in gpio[25], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_DEPENDENT],
+['IO[29]', H_DEPENDENT],
+['IO[28]', H_INDEPENDENT],
+['IO[27]', H_DEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_414/gpio_config_def_part_414_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_414/gpio_config_def_part_414_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 414
+# io_config -- version 1.2.2
+part = 414
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_DEPENDENT],
+['IO[3]', H_DEPENDENT],
+['IO[4]', H_DEPENDENT],
+['IO[5]', H_DEPENDENT],
+['IO[6]', H_DEPENDENT],
+['IO[7]', H_INDEPENDENT],
+['IO[8]', H_DEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_INDEPENDENT],
+['IO[12]', H_DEPENDENT],
+['IO[13]', H_DEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.45
+# configuration failed in gpio[26], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_DEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_DEPENDENT],
+['IO[32]', H_INDEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_INDEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_415/gpio_config_def_part_415_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_415/gpio_config_def_part_415_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 415
+# io_config -- version 1.2.2
+part = 415
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[8], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_DEPENDENT],
+    ['IO[2]', H_DEPENDENT],
+    ['IO[3]', H_DEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_INDEPENDENT],
+    ['IO[7]', H_INDEPENDENT],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# configuration failed in gpio[21], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_DEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_DEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_DEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_DEPENDENT],
+['IO[26]', H_DEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_416/gpio_config_def_part_416_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_416/gpio_config_def_part_416_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 416
+# io_config -- version 1.2.2
+part = 416
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_l = [
+['IO[0]', H_NONE],
+['IO[1]', H_INDEPENDENT],
+['IO[2]', H_INDEPENDENT],
+['IO[3]', H_INDEPENDENT],
+['IO[4]', H_DEPENDENT],
+['IO[5]', H_DEPENDENT],
+['IO[6]', H_DEPENDENT],
+['IO[7]', H_INDEPENDENT],
+['IO[8]', H_DEPENDENT],
+['IO[9]', H_DEPENDENT],
+['IO[10]', H_INDEPENDENT],
+['IO[11]', H_INDEPENDENT],
+['IO[12]', H_DEPENDENT],
+['IO[13]', H_INDEPENDENT],
+['IO[14]', H_INDEPENDENT],
+['IO[15]', H_INDEPENDENT],
+['IO[16]', H_INDEPENDENT],
+['IO[17]', H_INDEPENDENT],
+['IO[18]', H_INDEPENDENT],
+]
+# voltage: 1.45
+# configuration failed in gpio[33], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_DEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_UNKNOWN],
+['IO[32]', H_UNKNOWN],
+['IO[31]', H_UNKNOWN],
+['IO[30]', H_UNKNOWN],
+['IO[29]', H_UNKNOWN],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_417/gpio_config_def_part_417_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_417/gpio_config_def_part_417_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 417
+# io_config -- version 1.2.2
+part = 417
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[4], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_DEPENDENT],
+    ['IO[3]', H_INDEPENDENT],
+    ['IO[4]', H_UNKNOWN],
+    ['IO[5]', H_UNKNOWN],
+    ['IO[6]', H_UNKNOWN],
+    ['IO[7]', H_UNKNOWN],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_DEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_DEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_DEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_50/gpio_config_def_part_50_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_50/gpio_config_def_part_50_1_45_V.py
@@ -1,0 +1,12 @@
+# gpio_config_def.py file for part 50
+# io_config -- version 1.2.2
+part = 50
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_50/gpio_config_def_part_50_1_65_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_50/gpio_config_def_part_50_1_65_V.py
@@ -1,0 +1,12 @@
+# gpio_config_def.py file for part 50
+# io_config -- version 1.2.2
+part = 50
+voltage = 1.65
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_50/gpio_config_def_part_50_1_6_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_50/gpio_config_def_part_50_1_6_V.py
@@ -1,0 +1,12 @@
+# gpio_config_def.py file for part 50
+# io_config -- version 1.2.2
+part = 50
+voltage = 1.60
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_50/gpio_config_def_part_50_1_8_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_50/gpio_config_def_part_50_1_8_V.py
@@ -1,0 +1,12 @@
+# gpio_config_def.py file for part 50
+# io_config -- version 1.2.2
+part = 50
+voltage = 1.80
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_50/gpio_config_def_part_50_2_0_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_50/gpio_config_def_part_50_2_0_V.py
@@ -1,0 +1,12 @@
+# gpio_config_def.py file for part 50
+# io_config -- version 1.2.2
+part = 50
+voltage = 2.00
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_70/gpio_config_def_part_70_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_70/gpio_config_def_part_70_1_45_V.py
@@ -1,0 +1,11 @@
+# gpio_config_def.py file for part 70
+# io_config -- version 1.2.2
+voltage = 1.45
+analog = False
+
+H_NONE        = 0  
+H_DEPENDENT   = 1  
+H_INDEPENDENT = 2  
+H_SPECIAL     = 3  
+H_UNKNOWN     = 4  
+

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_9/gpio_config_def_part_9_1_40_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_9/gpio_config_def_part_9_1_40_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 9
+# io_config -- version 1.2.2
+part = 9
+voltage = 1.40
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.4
+# configuration failed in gpio[2], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_UNKNOWN],
+    ['IO[3]', H_UNKNOWN],
+    ['IO[4]', H_UNKNOWN],
+    ['IO[5]', H_UNKNOWN],
+    ['IO[6]', H_UNKNOWN],
+    ['IO[7]', H_UNKNOWN],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.4
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_DEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_9/gpio_config_def_part_9_1_45_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_9/gpio_config_def_part_9_1_45_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 9
+# io_config -- version 1.2.2
+part = 9
+voltage = 1.45
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.45
+# configuration failed in gpio[1], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_UNKNOWN],
+    ['IO[2]', H_UNKNOWN],
+    ['IO[3]', H_UNKNOWN],
+    ['IO[4]', H_UNKNOWN],
+    ['IO[5]', H_UNKNOWN],
+    ['IO[6]', H_UNKNOWN],
+    ['IO[7]', H_UNKNOWN],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.45
+# IO configuration chain was successful
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_INDEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_DEPENDENT],
+['IO[31]', H_INDEPENDENT],
+['IO[30]', H_INDEPENDENT],
+['IO[29]', H_INDEPENDENT],
+['IO[28]', H_DEPENDENT],
+['IO[27]', H_INDEPENDENT],
+['IO[26]', H_INDEPENDENT],
+['IO[25]', H_DEPENDENT],
+['IO[24]', H_INDEPENDENT],
+['IO[23]', H_INDEPENDENT],
+['IO[22]', H_INDEPENDENT],
+['IO[21]', H_INDEPENDENT],
+['IO[20]', H_INDEPENDENT],
+['IO[19]', H_INDEPENDENT],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_9/gpio_config_def_part_9_1_80_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_9/gpio_config_def_part_9_1_80_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 9
+# io_config -- version 1.2.2
+part = 9
+voltage = 1.80
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.8
+# configuration failed in gpio[1], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_UNKNOWN],
+    ['IO[2]', H_UNKNOWN],
+    ['IO[3]', H_UNKNOWN],
+    ['IO[4]', H_UNKNOWN],
+    ['IO[5]', H_UNKNOWN],
+    ['IO[6]', H_UNKNOWN],
+    ['IO[7]', H_UNKNOWN],
+    ['IO[8]', H_UNKNOWN],
+    ['IO[9]', H_UNKNOWN],
+    ['IO[10]', H_UNKNOWN],
+    ['IO[11]', H_UNKNOWN],
+    ['IO[12]', H_UNKNOWN],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.8
+# configuration failed in gpio[32], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_DEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_UNKNOWN],
+['IO[31]', H_UNKNOWN],
+['IO[30]', H_UNKNOWN],
+['IO[29]', H_UNKNOWN],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/nucleo_firmware/gpio_config_files/part_9/gpio_config_def_part_9_1_8_V.py
+++ b/gpio_test/nucleo_firmware/gpio_config_files/part_9/gpio_config_def_part_9_1_8_V.py
@@ -1,0 +1,58 @@
+# gpio_config_def.py file for part 9
+# io_config -- version 1.2.2
+part = 9
+voltage = 1.80
+analog = False
+
+H_NONE        = 0
+H_DEPENDENT   = 1
+H_INDEPENDENT = 2
+H_SPECIAL     = 3
+H_UNKNOWN     = 4
+
+# voltage: 1.8
+# configuration failed in gpio[13], anything after is invalid
+gpio_l = [
+    ['IO[0]', H_NONE],
+    ['IO[1]', H_INDEPENDENT],
+    ['IO[2]', H_DEPENDENT],
+    ['IO[3]', H_DEPENDENT],
+    ['IO[4]', H_DEPENDENT],
+    ['IO[5]', H_DEPENDENT],
+    ['IO[6]', H_DEPENDENT],
+    ['IO[7]', H_DEPENDENT],
+    ['IO[8]', H_INDEPENDENT],
+    ['IO[9]', H_DEPENDENT],
+    ['IO[10]', H_INDEPENDENT],
+    ['IO[11]', H_INDEPENDENT],
+    ['IO[12]', H_INDEPENDENT],
+    ['IO[13]', H_UNKNOWN],
+    ['IO[14]', H_UNKNOWN],
+    ['IO[15]', H_UNKNOWN],
+    ['IO[16]', H_UNKNOWN],
+    ['IO[17]', H_UNKNOWN],
+    ['IO[18]', H_UNKNOWN],
+]
+# voltage: 1.8
+# configuration failed in gpio[32], anything before is invalid
+gpio_h = [
+['IO[37]', H_NONE],
+['IO[36]', H_INDEPENDENT],
+['IO[35]', H_DEPENDENT],
+['IO[34]', H_INDEPENDENT],
+['IO[33]', H_INDEPENDENT],
+['IO[32]', H_UNKNOWN],
+['IO[31]', H_UNKNOWN],
+['IO[30]', H_UNKNOWN],
+['IO[29]', H_UNKNOWN],
+['IO[28]', H_UNKNOWN],
+['IO[27]', H_UNKNOWN],
+['IO[26]', H_UNKNOWN],
+['IO[25]', H_UNKNOWN],
+['IO[24]', H_UNKNOWN],
+['IO[23]', H_UNKNOWN],
+['IO[22]', H_UNKNOWN],
+['IO[21]', H_UNKNOWN],
+['IO[20]', H_UNKNOWN],
+['IO[19]', H_UNKNOWN],
+]

--- a/gpio_test/riscv_firmware_src/isr.c
+++ b/gpio_test/riscv_firmware_src/isr.c
@@ -1,20 +1,19 @@
 // This file is Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
 // License: BSD
 
-#include <defs.h>
-#include <irq_vex.h>
+#include "isr.h"
 
 uint16_t flag;
 
 void isr(void) {
-    irq_setmask(0);
-    reg_timer0_irq_en = 0; // disable interrupt
+  irq_setmask(0);
+  reg_timer0_irq_en = 0; // disable interrupt
 
-    reg_timer0_update = 1;
-    if (reg_timer0_value == 0)
-        flag = 1;
-    else
-        reg_timer0_irq_en = 1;
+  reg_timer0_update = 1;
+  if (reg_timer0_value == 0)
+    flag = 1;
+  else
+    reg_timer0_irq_en = 1;
 
-    return;
+  return;
 }

--- a/gpio_test/riscv_firmware_src/isr.h
+++ b/gpio_test/riscv_firmware_src/isr.h
@@ -1,0 +1,11 @@
+#ifndef _ISR_H_
+#define _ISR_H_
+
+#include <defs.h>
+#include <irq_vex.h>
+
+uint16_t flag;
+
+void isr(void);
+
+#endif /* _ISR_H_ */

--- a/gpio_test/riscv_firmware_src/print_io.c
+++ b/gpio_test/riscv_firmware_src/print_io.c
@@ -1,164 +1,163 @@
 #include "print_io.h"
-#include <gpio_config_io.h>
 
 void uart_putchar(uint32_t c) {
-    if (c == '\n')
-        uart_putchar('\r');
-    while (reg_uart_txfull == 1)
-        ;
-    reg_uart_data = c;
+  if (c == '\n')
+    uart_putchar('\r');
+  while (reg_uart_txfull == 1)
+    ;
+  reg_uart_data = c;
 }
 
 void print(const char *p) {
-    while (*p) {
-        uart_putchar(*(p++));
-        delay(1000);
-    }
+  while (*p) {
+    uart_putchar(*(p++));
+    delay(1000);
+  }
 }
 
 void print_hex(uint32_t v, int digits) {
-    for (int i = digits - 1; i >= 0; i--) {
-        char c = "0123456789abcdef"[(v >> (4 * i)) & 15];
-        uart_putchar(c);
-    }
+  for (int i = digits - 1; i >= 0; i--) {
+    char c = "0123456789abcdef"[(v >> (4 * i)) & 15];
+    uart_putchar(c);
+  }
 }
 
 void print_dec(uint32_t v) {
-    if (v >= 2000) {
-        print("OVER");
-        return;
-    } else if (v >= 1000) {
-        uart_putchar('1');
-        v -= 1000;
-    } else
-        uart_putchar(' ');
+  if (v >= 2000) {
+    print("OVER");
+    return;
+  } else if (v >= 1000) {
+    uart_putchar('1');
+    v -= 1000;
+  } else
+    uart_putchar(' ');
 
-    if (v >= 900) {
-        uart_putchar('9');
-        v -= 900;
-    } else if (v >= 800) {
-        uart_putchar('8');
-        v -= 800;
-    } else if (v >= 700) {
-        uart_putchar('7');
-        v -= 700;
-    } else if (v >= 600) {
-        uart_putchar('6');
-        v -= 600;
-    } else if (v >= 500) {
-        uart_putchar('5');
-        v -= 500;
-    } else if (v >= 400) {
-        uart_putchar('4');
-        v -= 400;
-    } else if (v >= 300) {
-        uart_putchar('3');
-        v -= 300;
-    } else if (v >= 200) {
-        uart_putchar('2');
-        v -= 200;
-    } else if (v >= 100) {
-        uart_putchar('1');
-        v -= 100;
-    } else
-        uart_putchar('0');
+  if (v >= 900) {
+    uart_putchar('9');
+    v -= 900;
+  } else if (v >= 800) {
+    uart_putchar('8');
+    v -= 800;
+  } else if (v >= 700) {
+    uart_putchar('7');
+    v -= 700;
+  } else if (v >= 600) {
+    uart_putchar('6');
+    v -= 600;
+  } else if (v >= 500) {
+    uart_putchar('5');
+    v -= 500;
+  } else if (v >= 400) {
+    uart_putchar('4');
+    v -= 400;
+  } else if (v >= 300) {
+    uart_putchar('3');
+    v -= 300;
+  } else if (v >= 200) {
+    uart_putchar('2');
+    v -= 200;
+  } else if (v >= 100) {
+    uart_putchar('1');
+    v -= 100;
+  } else
+    uart_putchar('0');
 
-    if (v >= 90) {
-        uart_putchar('9');
-        v -= 90;
-    } else if (v >= 80) {
-        uart_putchar('8');
-        v -= 80;
-    } else if (v >= 70) {
-        uart_putchar('7');
-        v -= 70;
-    } else if (v >= 60) {
-        uart_putchar('6');
-        v -= 60;
-    } else if (v >= 50) {
-        uart_putchar('5');
-        v -= 50;
-    } else if (v >= 40) {
-        uart_putchar('4');
-        v -= 40;
-    } else if (v >= 30) {
-        uart_putchar('3');
-        v -= 30;
-    } else if (v >= 20) {
-        uart_putchar('2');
-        v -= 20;
-    } else if (v >= 10) {
-        uart_putchar('1');
-        v -= 10;
-    } else
-        uart_putchar('0');
+  if (v >= 90) {
+    uart_putchar('9');
+    v -= 90;
+  } else if (v >= 80) {
+    uart_putchar('8');
+    v -= 80;
+  } else if (v >= 70) {
+    uart_putchar('7');
+    v -= 70;
+  } else if (v >= 60) {
+    uart_putchar('6');
+    v -= 60;
+  } else if (v >= 50) {
+    uart_putchar('5');
+    v -= 50;
+  } else if (v >= 40) {
+    uart_putchar('4');
+    v -= 40;
+  } else if (v >= 30) {
+    uart_putchar('3');
+    v -= 30;
+  } else if (v >= 20) {
+    uart_putchar('2');
+    v -= 20;
+  } else if (v >= 10) {
+    uart_putchar('1');
+    v -= 10;
+  } else
+    uart_putchar('0');
 
-    if (v >= 9) {
-        uart_putchar('9');
-        v -= 9;
-    } else if (v >= 8) {
-        uart_putchar('8');
-        v -= 8;
-    } else if (v >= 7) {
-        uart_putchar('7');
-        v -= 7;
-    } else if (v >= 6) {
-        uart_putchar('6');
-        v -= 6;
-    } else if (v >= 5) {
-        uart_putchar('5');
-        v -= 5;
-    } else if (v >= 4) {
-        uart_putchar('4');
-        v -= 4;
-    } else if (v >= 3) {
-        uart_putchar('3');
-        v -= 3;
-    } else if (v >= 2) {
-        uart_putchar('2');
-        v -= 2;
-    } else if (v >= 1) {
-        uart_putchar('1');
-        v -= 1;
-    } else
-        uart_putchar('0');
+  if (v >= 9) {
+    uart_putchar('9');
+    v -= 9;
+  } else if (v >= 8) {
+    uart_putchar('8');
+    v -= 8;
+  } else if (v >= 7) {
+    uart_putchar('7');
+    v -= 7;
+  } else if (v >= 6) {
+    uart_putchar('6');
+    v -= 6;
+  } else if (v >= 5) {
+    uart_putchar('5');
+    v -= 5;
+  } else if (v >= 4) {
+    uart_putchar('4');
+    v -= 4;
+  } else if (v >= 3) {
+    uart_putchar('3');
+    v -= 3;
+  } else if (v >= 2) {
+    uart_putchar('2');
+    v -= 2;
+  } else if (v >= 1) {
+    uart_putchar('1');
+    v -= 1;
+  } else
+    uart_putchar('0');
 }
 
 void print_digit(uint32_t v) {
-    v &= (uint32_t)0x000F;
+  v &= (uint32_t)0x000F;
 
-    if (v == 9) {
-        uart_putchar('9');
-    } else if (v == 8) {
-        uart_putchar('8');
-    } else if (v == 7) {
-        uart_putchar('7');
-    } else if (v == 6) {
-        uart_putchar('6');
-    } else if (v == 5) {
-        uart_putchar('5');
-    } else if (v == 4) {
-        uart_putchar('4');
-    } else if (v == 3) {
-        uart_putchar('3');
-    } else if (v == 2) {
-        uart_putchar('2');
-    } else if (v == 1) {
-        uart_putchar('1');
-    } else if (v == 0) {
-        uart_putchar('0');
-    } else if (v == 10) {
-        uart_putchar('a');
-    } else if (v == 11) {
-        uart_putchar('b');
-    } else if (v == 12) {
-        uart_putchar('c');
-    } else if (v == 13) {
-        uart_putchar('d');
-    } else if (v == 14) {
-        uart_putchar('e');
-    } else if (v == 15) {
-        uart_putchar('f');
-    } else
-        uart_putchar('*');
+  if (v == 9) {
+    uart_putchar('9');
+  } else if (v == 8) {
+    uart_putchar('8');
+  } else if (v == 7) {
+    uart_putchar('7');
+  } else if (v == 6) {
+    uart_putchar('6');
+  } else if (v == 5) {
+    uart_putchar('5');
+  } else if (v == 4) {
+    uart_putchar('4');
+  } else if (v == 3) {
+    uart_putchar('3');
+  } else if (v == 2) {
+    uart_putchar('2');
+  } else if (v == 1) {
+    uart_putchar('1');
+  } else if (v == 0) {
+    uart_putchar('0');
+  } else if (v == 10) {
+    uart_putchar('a');
+  } else if (v == 11) {
+    uart_putchar('b');
+  } else if (v == 12) {
+    uart_putchar('c');
+  } else if (v == 13) {
+    uart_putchar('d');
+  } else if (v == 14) {
+    uart_putchar('e');
+  } else if (v == 15) {
+    uart_putchar('f');
+  } else
+    uart_putchar('*');
 }

--- a/gpio_test/riscv_firmware_src/print_io.h
+++ b/gpio_test/riscv_firmware_src/print_io.h
@@ -2,6 +2,7 @@
 #define _PRINT_IO_H_
 
 #include <defs.h>
+#include <gpio_config_io.h>
 
 void uart_putchar(uint32_t c);
 void print(const char *p);

--- a/gpio_test/riscv_firmware_src/send_packet.c
+++ b/gpio_test/riscv_firmware_src/send_packet.c
@@ -1,61 +1,60 @@
 #include "send_packet.h"
-#include "../../riscv_firmware_src/defs.h"
 
 void count_down(const int d) {
-    /* Configure timer for a single-shot countdown */
-    reg_timer0_config = 0;
-    reg_timer0_data = d;
-    reg_timer0_config = 1; /* Enabled, one-shot, down count */
+  /* Configure timer for a single-shot countdown */
+  reg_timer0_config = 0;
+  reg_timer0_data = d;
+  reg_timer0_config = 1; /* Enabled, one-shot, down count */
 
-    // Loop, waiting for value to reach zero
-    reg_timer0_update = 1; // latch current value
-    while (reg_timer0_value > 0) {
-        reg_timer0_update = 1;
-    }
+  // Loop, waiting for value to reach zero
+  reg_timer0_update = 1; // latch current value
+  while (reg_timer0_value > 0) {
+    reg_timer0_update = 1;
+  }
 }
 
 void send_pulse_io37() {
-    int mask = 0x1F;
-    int temp = reg_mprj_datah & mask;
-    reg_mprj_datah = temp; // 0
-    count_down(PULSE_WIDTH);
-    temp = reg_mprj_datah;
-    reg_mprj_datah = temp | 0x20; // 1
-    count_down(PULSE_WIDTH);
+  int mask = 0x1F;
+  int temp = reg_mprj_datah & mask;
+  reg_mprj_datah = temp; // 0
+  count_down(PULSE_WIDTH);
+  temp = reg_mprj_datah;
+  reg_mprj_datah = temp | 0x20; // 1
+  count_down(PULSE_WIDTH);
 }
 
 void send_packet_io37(int num_pulses) {
-    // send pulses
-    for (int i = 0; i < num_pulses + 1; i++) {
-        send_pulse_io37();
-    }
-    // end of packet
-    count_down(PULSE_WIDTH * 10);
+  // send pulses
+  for (int i = 0; i < num_pulses + 1; i++) {
+    send_pulse_io37();
+  }
+  // end of packet
+  count_down(PULSE_WIDTH * 10);
 }
 
 int receive_io0() {
-    int mask = 0x1;
-    int old_received;
-    int received;
-    int pulse = 0;
-    int timeout_count = 0;
-    int timeout = 5000;
-    /*
-        flag == 1 --> increment
-        flag == 2 --> reset
-    */
-    int flag = 0;
-    old_received = reg_mprj_datal & mask;
-    send_packet_io37(2);
-    while (1) {
-        received = reg_mprj_datal & mask;
-        if (received != old_received) {
-            pulse++;
-            old_received = received;
-        }
-        if (pulse == 8) {
-            flag = 1;
-            return flag;
-        }
+  int mask = 0x1;
+  int old_received;
+  int received;
+  int pulse = 0;
+  // int timeout_count = 0;
+  // int timeout = 5000;
+  /*
+      flag == 1 --> increment
+      flag == 2 --> reset
+  */
+  int flag = 0;
+  old_received = reg_mprj_datal & mask;
+  send_packet_io37(2);
+  while (1) {
+    received = reg_mprj_datal & mask;
+    if (received != old_received) {
+      pulse++;
+      old_received = received;
     }
+    if (pulse == 8) {
+      flag = 1;
+      return flag;
+    }
+  }
 }

--- a/gpio_test/riscv_firmware_src/send_packet.h
+++ b/gpio_test/riscv_firmware_src/send_packet.h
@@ -1,6 +1,8 @@
 #ifndef SEND_PACKET_H
 #define SEND_PACKET_H
 
+#include <defs.h>
+
 #define PULSE_WIDTH 250000
 
 void count_down(const int d);

--- a/gpio_test/riscv_firmware_src/stub.c
+++ b/gpio_test/riscv_firmware_src/stub.c
@@ -14,17 +14,17 @@
  * limitations under the License.
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <defs.h>
+#include "stub.h"
 
 void uart_putchar(char c) {
-    if (c == '\n')
-        uart_putchar('\r');
-    while (reg_uart_txfull == 1)
-        ;
-    reg_uart_data = c;
+  if (c == '\n')
+    uart_putchar('\r');
+  while (reg_uart_txfull == 1)
+    ;
+  reg_uart_data = c;
 }
 
 void print(const char *p) {
-    while (*p)
-        uart_putchar(*(p++));
+  while (*p)
+    uart_putchar(*(p++));
 }

--- a/gpio_test/util/caravel_hkdebug.py
+++ b/gpio_test/util/caravel_hkdebug.py
@@ -107,7 +107,7 @@ gooddevs = []
 for dev in devlist:
     url = dev.split("(")[0].strip()
     name = "(" + dev.split("(")[1]
-    if name == "(Single RS232-HS)":
+    if name in ["(Single RS232-HS)", "(￿￿￿￿￿￿)"]:
         gooddevs.append(url)
 if len(gooddevs) == 0:
     print("Error:  No matching FTDI devices on USB bus!")

--- a/gpio_test/util/caravel_hkflash.py
+++ b/gpio_test/util/caravel_hkflash.py
@@ -379,7 +379,7 @@ class MyFtdi(Ftdi):
         for dev in devlist:
             url = dev.split("(")[0].strip()
             name = "(" + dev.split("(")[1]
-            if name == "(Single RS232-HS)":
+            if name in ["(Single RS232-HS)", "(￿￿￿￿￿￿)"]:
                 ftdi_devices.append(url)
         if len(ftdi_devices) == 0:
             logger.error("Error: No matching FTDI devices on USB bus!")

--- a/user_design/osc.v
+++ b/user_design/osc.v
@@ -44,7 +44,7 @@ module top (
     input wire [31:0] bram7_rd_data,
     output wire [7:0] bram7_config
 );
-    localparam N = 893;
+    localparam N = 393;
     wire [N:0] osc;
     genvar ii;
     generate


### PR DESCRIPTION
This cleans up the source files to build the firmware and adds files for the MPW4 ([ICESOC](https://github.com/nguyendao-uom/ICESOC)) tests.
Also adds support for an FTDI chip with only `0xfff` in the name and adds the compiler options `-Wall` and  `-Wpedantic`.